### PR TITLE
Docs: Expand on JSX docs / Spread Attributes (Transferring props with ...)

### DIFF
--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -247,6 +247,39 @@ function App2() {
 
 Spread attributes can be useful when you are building generic containers. However, they can also make your code messy by making it easy to pass a lot of irrelevant props to components that don't care about them. We recommend that you use this syntax sparingly.
 
+An alternative to spreading all of your props is to specifically list out all the properties that you would like to consume, followed by `...other`.
+
+```js{7}
+const { type, children, ...other } = props;
+```
+
+This ensures that you pass down all the props *except* the ones you're consuming yourself.
+
+```js{7}
+const handleClick = () => console.log("handleClick");
+
+const PrimaryButton = props => {
+  const { type, children, ...other } = props;
+  return (
+    <button type={type} {...other}>
+      {children}
+    </button>
+  );
+};
+
+const App = () => {
+  return (
+    <div>
+      <PrimaryButton type="button" onClick={handleClick}>
+        Hello World!
+      </PrimaryButton>
+    </div>
+  );
+};
+```
+
+In the example above, the `...other` object contains `{ onClick: handleClick() }` but not the `type` or `children` props. This makes a component like the `PrimaryButton` more reusable and flexible because it can extract a set of unknown properties like `onClick` in the above example. 
+
 ## Children in JSX
 
 In JSX expressions that contain both an opening tag and a closing tag, the content between those tags is passed as a special prop: `props.children`. There are several different ways to pass children:


### PR DESCRIPTION
resolves https://github.com/reactjs/reactjs.org/issues/109

This brings over the [Transferring with `...` in JSX](https://github.com/facebook/react/blob/v15.4.0-rc.3/docs/docs/06-transferring-props.md#transferring-with--in-jsx) documentation that was previously published in version 15-ish. 

The overall content has been kept the same but I slightly changed the example to better reflect why using `...other` can be useful (I also wanted to avoid an example that uses a `<div>` as a checkbox).

In the example, I show a PrimaryButton component that can receive an unknown `onClick` prop function. Things like buttons handle a lot of different events -- instead of passing every possible synthetic event down as a prop, making use of `...other` helps to keep the code for `PrimaryButton` from getting bloated.

If it helps, I've also made the example live on code sandbox but didn't include it...I wasn't sure if it was totally needed, and since the docs surface codepen examples exclusively. I don't know if you all want to stay consistent with one example platform.

[![Edit React: Transferring with `...` in JSX](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/j2vzz8j0z5)